### PR TITLE
Loop through env vars on guard.go

### DIFF
--- a/pkg/guard.go
+++ b/pkg/guard.go
@@ -6,34 +6,20 @@ import (
 )
 
 func GuardEnvVars() error {
-	_, httpHost := os.LookupEnv("HTTP_PORT")
-	if !httpHost {
-		return errors.New("Missing HTTP_PORT in environment variable")
+	envs := []string{
+		"HTTP_PORT",
+		"SLACK_WEBHOOK_URL",
+		"MESSAGE",
+		"MERGE_REQUEST_LABEL",
+		"SLACK_USERNAME",
+		"SLACK_AVATAR_URL",
 	}
 
-	_, slackWebhookUrl := os.LookupEnv("SLACK_WEBHOOK_URL")
-	if !slackWebhookUrl {
-		return errors.New("Missing SLACK_WEBHOOK_URL in environment variable")
-	}
-
-	_, message := os.LookupEnv("MESSAGE")
-	if !message {
-		return errors.New("Missing MESSAGE in environment variable")
-	}
-
-	_, mergeRequestLabel := os.LookupEnv("MERGE_REQUEST_LABEL")
-	if !mergeRequestLabel {
-		return errors.New("Missing MERGE_REQUEST_LABEL in environment variable")
-	}
-
-	_, slackUsername := os.LookupEnv("SLACK_USERNAME")
-	if !slackUsername {
-		return errors.New("Missing SLACK_USERNAME in environment variable")
-	}
-
-	_, slackAvatarUrl := os.LookupEnv("SLACK_AVATAR_URL")
-	if !slackAvatarUrl {
-		return errors.New("Missing SLACK_AVATAR_URL in environment variable")
+	for _, env := range envs {
+		_, value := os.LookupEnv(env)
+		if !value {
+			return errors.New("Missing " + env + " in environment variable")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This commit combines all possible environment variables into a single slice of strings. This reduces the amount of code and improves readability.