### PR TITLE
Create models package

### DIFF
--- a/models/merge_request.go
+++ b/models/merge_request.go
@@ -1,9 +1,10 @@
-package pkg
+package models
 
 import "time"
 
 // Generated via https://mholt.github.io/json-to-go/
 
+// MergeRequestInfo defines the data model of a single Merge Request
 type MergeRequestInfo struct {
 	ObjectKind string `json:"object_kind"`
 	EventType  string `json:"event_type"`

--- a/pkg/json_decode.go
+++ b/pkg/json_decode.go
@@ -2,10 +2,11 @@ package pkg
 
 import (
 	"encoding/json"
+	"turboenigma/models"
 )
 
-func JsonDecode(jsonString string) MergeRequestInfo {
-	var mergeRequest MergeRequestInfo
+func JsonDecode(jsonString string) models.MergeRequestInfo {
+	var mergeRequest models.MergeRequestInfo
 
 	if err := json.Unmarshal([]byte(jsonString), &mergeRequest); err != nil {
 		panic(err)


### PR DESCRIPTION
This change co-locates the MergeRequestInfo struct into a package of its own, therefore reducing the amount of files in the pkg folder. This will also allow the sharing of structs in case we need to create different packages in the future.