### PR TITLE
Build image with a scratch base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
-FROM golang:1.16-alpine
-WORKDIR /go/src/app
-ADD . .
+FROM golang:1.16-alpine AS builder
+RUN mkdir -p /turbo-enigma
+WORKDIR /turbo-enigma
+
+COPY go.* ./
+RUN go mod download
+
+COPY . ./
+RUN CGO_ENABLED=0 GOOS=linux go build -o bin/turbo-enigma
+
+FROM scratch
+
+COPY --from=builder /turbo-enigma/bin/. /.
+
 ENV HTTP_PORT=80
 ENV MERGE_REQUEST_LABEL="just-testing"
 ENV MESSAGE="New Merge Request Created"
 ENV SLACK_AVATAR_URL="https://avatars.githubusercontent.com/u/46966179?s=200&v=4"
 ENV SLACK_USERNAME="codelicia/turbo-enigma"
 ENV SLACK_WEBHOOK_URL="http://turboenigma.localhost"
-RUN go build
-CMD ["./turboenigma"]
+
+ENTRYPOINT ["/turbo-enigma"]


### PR DESCRIPTION
Using Docker multi-stage builds we can create a container with no OS at all and just the go binary ready to be used.

As a reference:
```
REPOSITORY                      TAG       IMAGE ID       CREATED          SIZE
before                          latest    6415837af929   28 seconds ago   309MB
after                           latest    6db5ef6e79a8   5 minutes ago    7.38MB
```