### PR TITLE
Add ca certificates to image built from scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o bin/turbo-enigma
 FROM scratch
 
 COPY --from=builder /turbo-enigma/bin/. /.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ENV HTTP_PORT=80
 ENV MERGE_REQUEST_LABEL="just-testing"


### PR DESCRIPTION
When we try to call a secure endpoint the ca certificate will be
checked. Since the image was built from scratch no certificates were
available and the call would fail with the message:

  x509: certificate signed by unknown authority