### PR TITLE
Fix multiple labels on rules

### DIFF
--- a/provider/slack.go
+++ b/provider/slack.go
@@ -62,8 +62,10 @@ func (s *Slack) ChannelsForMergeRequest(mergeRequest model.MergeRequestInfo) []s
 
 	for _, config := range s.notificationRules {
 		for _, mrLabel := range mergeRequest.Labels {
-			if mrLabel.Title == config.Labels[0] {
-				channels = append(channels, config.Channel)
+			for _, ruleLabel := range config.Labels {
+				if mrLabel.Title == ruleLabel {
+					channels = append(channels, config.Channel)
+				}
 			}
 		}
 	}

--- a/provider/slack_test.go
+++ b/provider/slack_test.go
@@ -66,6 +66,34 @@ func TestChannelsForMergeRequestMultipleRules(t *testing.T) {
 	assert.Equal(t, []string{"#multiple-rules"}, slack.ChannelsForMergeRequest(mergeRequest))
 }
 
+func TestChannelsForMergeRequestMultipleRulesWithMoreThanOneLabel(t *testing.T) {
+	var mergeRequest model.MergeRequestInfo
+	var jsonString string
+	var notifications []model.NotificationRule
+
+	payload, err := ioutil.ReadFile("../payload/merge_request-open-enabling-team.json")
+	assert.Empty(t, err)
+
+	err = json.Unmarshal(payload, &mergeRequest)
+	assert.Empty(t, err)
+	assert.Equal(t, "Enabling Team", mergeRequest.Labels[0].Title)
+
+	jsonString = "[{\"channel\":\"#tested\",\"labels\":[\"just-testing\", \"find-my-bug\"]},{\"channel\":\"#multiple-rules\",\"labels\":[\"Team Magie Lee\", \"Enabling Team\"]}]"
+	err = json.Unmarshal([]byte(jsonString), &notifications)
+	assert.Empty(t, err)
+
+	slack := NewSlack(
+		http.DefaultClient,
+		notifications,
+		"https://testing.com",
+		"New MR",
+		"https://avatar",
+		"Username",
+	)
+
+	assert.Equal(t, []string{"#multiple-rules"}, slack.ChannelsForMergeRequest(mergeRequest))
+}
+
 func TestChannelsForMergeRequestNotMatchingLabel(t *testing.T) {
 	var mergeRequest model.MergeRequestInfo
 	var jsonString string


### PR DESCRIPTION
We had a bug for rules with more than one label. Just the first label on the rule was considered.