### PR TITLE
Configure project root as charts_dir

### DIFF
--- a/.github/workflows/helm-chart-releaser.yml
+++ b/.github/workflows/helm-chart-releaser.yml
@@ -26,5 +26,7 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1
+        with:
+          charts_dir: .
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-appVersion: "0.1.1"
+appVersion: "0.1.0"
 description: ⚡️ Gitlab notifier for Slack 🔋
 icon: https://avatars.githubusercontent.com/u/46966179?s=200&v=4
 name: turbo-enigma
 type: application
-version: 0.1.1
+version: 0.1.0


### PR DESCRIPTION
Chart releaser is expecting a path with charts inside:

        charts/
        ├── turbo-enigma/
        │   ├── values.yaml
        │   └── Chart.yaml
        └── something-else/
            ├── values.yaml
            └── Chart.yaml

By setting the root (.) as the charts_dir we can make it
work with the current structure:

        ./
        └── helm/
            ├── values.yaml
            └── Chart.yaml
