### PR TITLE
Remove Slack Webhook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,5 @@ ENV MESSAGE="New Merge Request Created"
 ENV SLACK_AVATAR_URL="https://avatars.githubusercontent.com/u/46966179?s=200&v=4"
 ENV SLACK_USERNAME="codelicia/turbo-enigma"
 ENV SLACK_TOKEN="slack-token"
-ENV SLACK_WEBHOOK_URL="http://turboenigma.localhost"
 
 ENTRYPOINT ["/turbo-enigma"]

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ image/build:
 
 app/run:
 	docker run -it --rm -p 8000:80 \
-		-e SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL}" \
 		-e SLACK_TOKEN="${SLACK_TOKEN}" \
 		-e NOTIFICATION_RULES="${NOTIFICATION_RULES}" \
 		-e REACTION_RULES="${REACTION_RULES}" \

--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@ Turbo Enigma ⚡️🔋
 Environment
 -----------
 
-The application will need the Slack webhook URL. you can place it in the `.env.local`. 
-if the file does not exist, you can duplicate it from `.env.local.dist`, otherwise it will get created the first time you run `make` 
+The application will need the
+[Slack Token](https://api.slack.com/tutorials/tracks/getting-a-token) with
+scopes `message:write`, `search:read` and `reactions:write`. You can place it
+in the `.env.local`. if the file does not exist, you can duplicate it from
+`.env.local.dist`, otherwise it will get created the first time you run `make` 
 ```
-export SLACK_WEBHOOK_URL="https://find-me-on.slack.com"
+export SLACK_TOKEN="find-me-on-slack"
 ```
 
 Deploying
@@ -15,7 +18,7 @@ Deploying
 
 ```
 cp charts/turbo-enigma/values.yaml.dist charts/turbo-enigma/values.yaml
-helm upgrade --install my-enigma charts/turbo-enigma --set slack.webhookUrl=$SLACK_WEBHOOK_URL
+helm upgrade --install my-enigma charts/turbo-enigma --set slack.token=$SLACK_TOKEN
 ```
 
 Redeploying
@@ -23,7 +26,7 @@ Redeploying
 
 ```
 vim charts/turbo-enigma/values.yaml # Adding new notification rules for instance
-helm upgrade --install my-enigma charts/turbo-enigma --set slack.webhookUrl=$SLACK_WEBHOOK_URL
+helm upgrade --install my-enigma charts/turbo-enigma --set slack.token=$SLACK_TOKEN
 ```
 
 Build

--- a/charts/turbo-enigma/templates/configmap.yaml
+++ b/charts/turbo-enigma/templates/configmap.yaml
@@ -9,5 +9,4 @@ data:
   MESSAGE: {{ .Values.slack.message | quote }}
   SLACK_AVATAR_URL: {{ .Values.slack.avatarUrl | quote }}
   SLACK_USERNAME: {{ .Values.slack.username | quote }}
-  SLACK_WEBHOOK_URL: {{ .Values.slack.webhookUrl | quote }}
   SLACK_TOKEN: {{ .Values.slack.token | quote }}

--- a/charts/turbo-enigma/values.yaml.dist
+++ b/charts/turbo-enigma/values.yaml.dist
@@ -9,7 +9,6 @@ slack:
   avatarUrl: "https://avatars.githubusercontent.com/u/46966179?s=200&v=4"
   message: "New Merge Request Created"
   username: "codelicia/turbo-enigma"
-  webhookUrl: http://slack-webhook.localhost
   token: xoxp-slack-token
 
 notificationRules:

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ func InitEnvironment() *Env {
 		"REACTION_RULES",
 		"SLACK_AVATAR_URL",
 		"SLACK_USERNAME",
-		"SLACK_WEBHOOK_URL",
 		"SLACK_TOKEN",
 	})
 	if err != nil {
@@ -44,7 +43,6 @@ func main() {
 		http.DefaultClient,
 		notificationRules,
 		reactionRules,
-		EnvManager.Get("SLACK_WEBHOOK_URL"),
 		EnvManager.Get("SLACK_TOKEN"),
 		EnvManager.Get("MESSAGE"),
 		EnvManager.Get("SLACK_AVATAR_URL"),

--- a/main_test.go
+++ b/main_test.go
@@ -14,7 +14,6 @@ func setupTestEnvironmentVariables() {
 	os.Setenv("REACTION_RULES", `[{"action":"approved", "reaction":"thumbsup"}]`)
 	os.Setenv("SLACK_AVATAR_URL", "Just testing...")
 	os.Setenv("SLACK_USERNAME", "Just testing...")
-	os.Setenv("SLACK_WEBHOOK_URL", "Just testing...")
 	os.Setenv("SLACK_TOKEN", "xoxp-slack-token")
 }
 
@@ -82,17 +81,6 @@ func TestEnvironmentMissingSlackUsername(t *testing.T) {
 	InitEnvironment()
 
 	t.Error("should panic about missing env: SLACK_USERNAME")
-}
-
-func TestEnvironmentMissingSlackWebhookUrl(t *testing.T) {
-	defer func() { recover() }()
-
-	setupTestEnvironmentVariables()
-	os.Unsetenv("SLACK_WEBHOOK_URL")
-
-	InitEnvironment()
-
-	t.Error("should panic about missing env: SLACK_WEBHOOK_URL")
 }
 
 func TestEnvironmentMissingSlackToken(t *testing.T) {

--- a/provider/slack.go
+++ b/provider/slack.go
@@ -37,15 +37,14 @@ type Slack struct {
 	client                                       HTTPClient
 	notificationRules                            []model.NotificationRule
 	reactionRules                                []model.ReactionRule
-	webhookURL, message, avatar, username, token string
+	message, avatar, username, token string
 }
 
-func NewSlack(client HTTPClient, notificationRules []model.NotificationRule, reactionRules []model.ReactionRule, webhookURL, token, message, avatar, username string) *Slack {
+func NewSlack(client HTTPClient, notificationRules []model.NotificationRule, reactionRules []model.ReactionRule, token, message, avatar, username string) *Slack {
 	return &Slack{
 		client:            client,
 		notificationRules: notificationRules,
 		reactionRules:     reactionRules,
-		webhookURL:        webhookURL,
 		token:             token,
 		message:           message,
 		avatar:            avatar,
@@ -143,12 +142,13 @@ func (s *Slack) NotifyMergeRequestMerged(mergeRequest model.MergeRequestInfo) er
 }
 
 func (s *Slack) sendMessage(message []byte) error {
-	req, err := http.NewRequest(http.MethodPost, s.webhookURL, bytes.NewBuffer(message))
+	req, err := http.NewRequest(http.MethodPost, "https://slack.com/api/chat.postMessage", bytes.NewBuffer(message))
 	if err != nil {
 		return err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.token))
 
 	resp, err := s.client.Do(req)
 	if err != nil {

--- a/provider/slack_test.go
+++ b/provider/slack_test.go
@@ -49,7 +49,6 @@ func TestChannelsForMergeRequestSingleRule(t *testing.T) {
 		http.DefaultClient,
 		notifications,
 		reactions,
-		"https://testing.com",
 		"New MR",
 		"https://avatar",
 		"Username",
@@ -84,7 +83,6 @@ func TestChannelsForMergeRequestMultipleRules(t *testing.T) {
 		http.DefaultClient,
 		notifications,
 		reactions,
-		"https://testing.com",
 		"New MR",
 		"https://avatar",
 		"Username",
@@ -119,7 +117,6 @@ func TestChannelsForMergeRequestMultipleRulesWithMoreThanOneLabel(t *testing.T) 
 		http.DefaultClient,
 		notifications,
 		reactions,
-		"https://testing.com",
 		"New MR",
 		"https://avatar",
 		"Username",
@@ -154,7 +151,6 @@ func TestChannelsForMergeRequestNotMatchingLabel(t *testing.T) {
 		http.DefaultClient,
 		notifications,
 		reactions,
-		"https://testing.com",
 		"New MR",
 		"https://avatar",
 		"Username",
@@ -178,7 +174,7 @@ func TestPostReaction(t *testing.T) {
 		}, nil
 	}
 
-	slack := NewSlack(client, notifications, reactions, "https://testing.com", "New MR", "https://avatar", "Username", "Token")
+	slack := NewSlack(client, notifications, reactions, "New MR", "https://avatar", "Username", "Token")
 
 	locatedMessage := LocatedMessage{
 		channelID:   "channel-id",
@@ -205,7 +201,7 @@ func TestPostReactionFailsWithStatusCode(t *testing.T) {
 		}, nil
 	}
 
-	slack := NewSlack(client, notifications, reactions, "https://testing.com", "New MR", "https://avatar", "Username", "Token")
+	slack := NewSlack(client, notifications, reactions, "New MR", "https://avatar", "Username", "Token")
 
 	locatedMessage := LocatedMessage{
 		channelID:   "channel-id",
@@ -228,7 +224,7 @@ func TestPostReactionFailsWithClientError(t *testing.T) {
 		return nil, errors.New("Error from web server")
 	}
 
-	slack := NewSlack(client, notifications, reactions, "https://testing.com", "New MR", "https://avatar", "Username", "Token")
+	slack := NewSlack(client, notifications, reactions, "New MR", "https://avatar", "Username", "Token")
 
 	locatedMessage := LocatedMessage{
 		channelID:   "channel-id",


### PR DESCRIPTION
We are using way more features from Slack API so will keep the project
simple to replace the webhook with an API call.