### PR TITLE
Skip helm chart upload if release exists

### DIFF
--- a/.github/workflows/helm-chart-releaser.yml
+++ b/.github/workflows/helm-chart-releaser.yml
@@ -28,3 +28,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: true


### PR DESCRIPTION
Helm chart releaser was failing if the same version was already created (no changes on the helm chart).